### PR TITLE
[feature] 增加 radiko 节目的下载/录制

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,7 @@
 /temp_*/
 tasks.json
 output.mkv
+output.ts
 /dist/
+
+yarn.lock

--- a/src/core/archive.ts
+++ b/src/core/archive.ts
@@ -127,6 +127,13 @@ class ArchiveDownloader extends Downloader {
                 parser.default.parse({
                     downloader: this
                 });
+            } else if (this.m3u8Path.includes('radiko.jp')){
+                // Radiko
+                this.Log.info('Site comfirmed: Radiko.');
+                const parser = await import('./parsers/radiko');
+                await parser.default.parse({
+                    downloader: this
+                });
             } else {
                 this.Log.warning(`Site is not supported by Minyami Core. Try common parser.`);
                 const parser = await import('./parsers/common');
@@ -159,7 +166,7 @@ class ArchiveDownloader extends Downloader {
             this.chunks = this.m3u8.chunks.map(chunk => {
                 return {
                     url: chunk.url,
-                    filename: this.onChunkNaming ? this.onChunkNaming(chunk) : chunk.url.match(/\/*([^\/]+?\.ts)/)[1],
+                    filename: this.onChunkNaming ? this.onChunkNaming(chunk) : chunk.url.match(/\/*([^\/]+?\.\w+)$/)[1],
                     key: chunk.key,
                     iv: chunk.iv,
                     sequenceId: chunk.sequenceId

--- a/src/core/live.ts
+++ b/src/core/live.ts
@@ -76,7 +76,6 @@ export default class LiveDownloader extends Downloader {
         await this.loadM3U8();
 
         this.playlists.push(this.m3u8);
-        this.timeout = Math.max(20000, this.m3u8.chunks.length * this.m3u8.getChunkLength() * 1000);
 
         if (this.m3u8.isEncrypted) {
             this.isEncrypted = true;
@@ -118,6 +117,13 @@ export default class LiveDownloader extends Downloader {
                 parser.default.parse({
                     downloader: this
                 });
+            } else if (this.m3u8Path.includes('smartstream.ne.jp')){
+                // Radiko
+                this.Log.info('Site comfirmed: Radiko.');
+                const parser = await import('./parsers/radiko');
+                await parser.default.parse({
+                    downloader: this
+                });
             } else {
                 this.Log.warning(`Site is not supported by Minyami Core. Try common parser.`);
                 const parser = await import('./parsers/common');
@@ -127,6 +133,7 @@ export default class LiveDownloader extends Downloader {
             }
         }
         this.emit('parsed');
+        this.timeout = Math.max(20000, this.m3u8.chunks.length * this.m3u8.getChunkLength() * 1000);
         await this.cycling();
     }
 
@@ -157,7 +164,7 @@ export default class LiveDownloader extends Downloader {
                     }
                 }
                 return {
-                    filename: this.onChunkNaming ? this.onChunkNaming(chunk) : chunk.url.match(/\/*([^\/]+?\.ts)/)[1],
+                    filename: this.onChunkNaming ? this.onChunkNaming(chunk) : chunk.url.match(/\/*([^\/]+?\.\w+)$/)[1],
                     isEncrypted: this.m3u8.isEncrypted,
                     key: chunk.key,
                     iv: chunk.iv,

--- a/src/core/parsers/radiko.ts
+++ b/src/core/parsers/radiko.ts
@@ -1,0 +1,18 @@
+import { ParserOptions, ParserResult } from './types'
+
+export default class Parser {
+    static prefix = ''
+    static parse({ downloader }: ParserOptions): ParserResult {
+        const realM3U8Url = downloader.m3u8.chunks[0].url
+        downloader.m3u8Path = realM3U8Url
+        return new Promise((resolve, reject) => {
+            downloader.loadM3U8()
+                .then(() => {
+                    resolve({})
+                })
+                .catch(err => {
+                    reject(err)
+                })
+        })
+    }
+}


### PR DESCRIPTION
- 增加了 [radiko.jp](http://radiko.jp/) 节目的下载/录制.
- 拓展了 m3u8 chunk url 的文件扩展名 (radiko 使用的是 `.aac`)

只要传入 `X-Radiko-AuthToken` 的 header 就可以了,值的获取方式可以参考[这里](https://gist.github.com/Yesterday17/2619137af70dfe98656206e45948a5f8)