### PR TITLE
处理包含冒号的 HTTP header 项目

### DIFF
--- a/src/core/downloader.ts
+++ b/src/core/downloader.ts
@@ -140,11 +140,12 @@ class Downloader extends EventEmitter {
 
         if (headers) {
             for (const h of headers.split('\n')) {
-                const header = h.split(':');
-                if (header.length !== 2) {
+                try {
+                    const header = /^([^ :]+):(.+)$/.exec(h).slice(1);
+                    this.headers[header[0]] = header[1].trim();
+                } catch (e) {
                     this.Log.error(`HTTP Headers invalid.`);
                 }
-                this.headers[header[0]] = header[1];
             }
         }
 


### PR DESCRIPTION
比如各种网址。应该不会造成兼容性问题（原来就是一个`split(':')`，并没有处理冒号后的 leading space，我也就不管它了）。
自己测试可以正常下载。