### PR TITLE
Use OS provided temporary directory

### DIFF
--- a/src/core/archive.ts
+++ b/src/core/archive.ts
@@ -8,6 +8,7 @@ import { saveTask, deleteTask, getTask } from '../utils/task';
 import { timeStringToSeconds } from '../utils/time';
 import { sleep } from './action';
 const path = require('path');
+const os = require('os');
 
 class ArchiveDownloader extends Downloader {
     tempPath: string;
@@ -142,7 +143,7 @@ class ArchiveDownloader extends Downloader {
         // Record start time to calculate speed.
         this.startedAt = new Date().valueOf();
         // Allocate temporary directory.
-        this.tempPath = path.resolve(__dirname, '../../temp_' + new Date().valueOf());
+        this.tempPath = path.resolve(os.tmpdir(), 'minyami_' + new Date().valueOf());
 
         if (!fs.existsSync(this.tempPath)) {
             fs.mkdirSync(this.tempPath);

--- a/src/core/live.ts
+++ b/src/core/live.ts
@@ -5,6 +5,7 @@ import { mergeToMKV, mergeToTS, download, decrypt } from "../utils/media";
 import { sleep } from "../utils/system";
 const path = require('path');
 const fs = require('fs');
+const os = require('os');
 
 /**
  * Live Downloader
@@ -55,7 +56,7 @@ export default class LiveDownloader extends Downloader {
         // Record start time to calculate speed.
         this.startedAt = new Date().valueOf();
         // Allocate temporary directory.
-        this.tempPath = path.resolve(__dirname, '../../temp_' + new Date().valueOf());
+        this.tempPath = path.resolve(os.tmpdir(), 'minyami_' + new Date().valueOf());
 
         if (!fs.existsSync(this.tempPath)) {
             fs.mkdirSync(this.tempPath);


### PR DESCRIPTION
Currently Minyami needs root privilege to write to the temporary directory if Minyami is installed via `sudo npm install -g minyami`. This PR will let it always use the OS-provided temporary directory so there won't be permission issues (and faster for users who mount a separate partition on /tmp).