### PR TITLE
Enabled http headers when --resume command selected

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ Help:
          --cookies <cookies>       Cookies to download
              <cookies>
          --headers <headers>       HTTP Headers used to download
-             <headers>             Multiple headers should be splited with \n. eg. --header "Cookie: a=1\nUser-Agent: X-UA". Don't forget to escape. This option will override --cookies.
+             <headers>             Multiple headers should be splited with \n. eg. --headers "Cookie: a=1\nUser-Agent: X-UA". Don't forget to escape. This option will override --cookies.
          --live                    Download live
          --format <format_name>    (Optional) Set output format. default: ts
              <format_name>         Format name. ts or mkv.

--- a/src/core/archive.ts
+++ b/src/core/archive.ts
@@ -482,6 +482,7 @@ class ArchiveDownloader extends Downloader {
         this.outputPath = previousTask.outputPath;
         this.threads = previousTask.threads;
         this.cookies = previousTask.cookies;
+        this.headers = previousTask.headers;
         this.key = previousTask.key;
         this.iv = previousTask.iv;
         this.verbose = previousTask.verbose;
@@ -559,6 +560,7 @@ class ArchiveDownloader extends Downloader {
                 outputPath: this.outputPath,
                 threads: this.threads,
                 cookies: this.cookies,
+                headers: this.headers,
                 key: this.key,
                 iv: this.iv,
                 verbose: this.verbose,

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,7 +203,7 @@ Erii.addOption({
     argument: {
         name: "headers",
         description:
-            'Multiple headers should be splited with \\n. eg. --header "Cookie: a=1\\nUser-Agent: X-UA". Don\'t forget to escape. This option will override --cookies.',
+            'Multiple headers should be splited with \\n. eg. --headers "Cookie: a=1\\nUser-Agent: X-UA". Don\'t forget to escape. This option will override --cookies.',
     },
 });
 

--- a/src/utils/task.ts
+++ b/src/utils/task.ts
@@ -12,6 +12,7 @@ export interface MinyamiTask {
     threads: number; // 并发数量
 
     cookies: string; // Cookie
+    headers: object; // HTTP Headers
     key: string; // Key
     iv: string; // IV
 


### PR DESCRIPTION
When --download command selected http headers worked fine, when --resume command selected http headers didnt work