### PR TITLE
fix(downloader): slice chunk filename

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ Help:
          --live                    Download live
          --format <format_name>    (Optional) Set output format. default: ts
              <format_name>         Format name. ts or mkv.
-         --proxy <proxy-server>    Download via Socks proxy (Deprecated)
+         --proxy <proxy-server>    Use the specified HTTP/HTTPS/SOCKS proxy
              <proxy-server>        Set proxy in [protocol://<host>:<port>] format. eg. --proxy "http://127.0.0.1:1080".
          --slice <range>           Download specified part of the stream
              <range>               Set time range in [<hh:mm:ss>-<hh:mm:ss> format]. eg. --slice "45:00-53:00"

--- a/src/core/archive.ts
+++ b/src/core/archive.ts
@@ -173,7 +173,7 @@ class ArchiveDownloader extends Downloader {
                     url: chunk.url,
                     filename: this.onChunkNaming
                         ? this.onChunkNaming(chunk)
-                        : new URL(chunk.url).pathname.split("/").slice(-1)[0],
+                        : new URL(chunk.url).pathname.split("/").slice(-1)[0].slice(8 - 255),
                     key: chunk.key,
                     iv: chunk.iv,
                     sequenceId: chunk.sequenceId,

--- a/src/core/live.ts
+++ b/src/core/live.ts
@@ -193,7 +193,7 @@ export default class LiveDownloader extends Downloader {
                 return {
                     filename: this.onChunkNaming
                         ? this.onChunkNaming(chunk)
-                        : new URL(chunk.url).pathname.split("/").slice(-1)[0],
+                        : new URL(chunk.url).pathname.split("/").slice(-1)[0].slice(8 - 255),
                     isEncrypted: this.m3u8.isEncrypted,
                     key: chunk.key,
                     iv: chunk.iv,

--- a/src/index.ts
+++ b/src/index.ts
@@ -231,7 +231,7 @@ Erii.addOption({
 Erii.addOption({
     name: ["proxy"],
     command: "download",
-    description: "Download via Socks proxy (Deprecated)",
+    description: "Use the specified HTTP/HTTPS/SOCKS proxy",
     argument: {
         name: "proxy-server",
         description: 'Set proxy in [protocol://<host>:<port>] format. eg. --proxy "http://127.0.0.1:1080".',


### PR DESCRIPTION
Use last `255 - 8` chars for temp chunk filename.

chore(doc): remove deprecation flag for proxy option