### PR TITLE
Add back ws dep (fix #125)

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -17,7 +17,8 @@
                 "crypto-js": "^4.2.0",
                 "erii": "^2.0.6",
                 "https-proxy-agent": "^7.0.2",
-                "socks-proxy-agent": "^8.0.2"
+                "socks-proxy-agent": "^8.0.2",
+                "ws": "^7.4.6"
             },
             "bin": {
                 "minyami": "dist/index.js"
@@ -1516,6 +1517,26 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true
         },
+        "node_modules/ws": {
+            "version": "7.4.6",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+            "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+            "engines": {
+                "node": ">=8.3.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/yaml": {
             "version": "1.10.2",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
@@ -2676,6 +2697,12 @@
                     "dev": true
                 }
             }
+        },
+        "ws": {
+            "version": "7.4.6",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+            "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+            "requires": {}
         },
         "yaml": {
             "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
         "crypto-js": "^4.2.0",
         "erii": "^2.0.6",
         "https-proxy-agent": "^7.0.2",
-        "socks-proxy-agent": "^8.0.2"
+        "socks-proxy-agent": "^8.0.2",
+        "ws": "^7.4.6"
     },
     "devDependencies": {
         "@types/node": "^17.0.17",


### PR DESCRIPTION
It was removed in https://github.com/Last-Order/Minyami/commit/cdb3f2593d253f861dc219b11506a51b6d41060e, probably by mistake.

I just used the version we used before (7.4.6) instead of newest 8.x just in case; feel free to change.