### PR TITLE
Warn only once per m3u8

### DIFF
--- a/src/core/m3u8.ts
+++ b/src/core/m3u8.ts
@@ -161,7 +161,8 @@ export class Playlist {
     private parse() {
         let key: string,
             iv: string,
-            isEncrypted = false;
+            isEncrypted = false,
+            warned = false;
         const lines = this.m3u8Content.split("\n");
         for (let i = 0; i <= lines.length - 1; i++) {
             /**
@@ -195,9 +196,12 @@ export class Playlist {
                     isEncrypted = false;
                 } else {
                     isEncrypted = false;
-                    logger.warning(
-                        `Unsupported encryption method: "${parsedTagBody["METHOD"]}". Chunks will not be decrypted.`
-                    );
+                    if (!warned) {
+                        logger.warning(
+                            `Unsupported encryption method: "${parsedTagBody["METHOD"]}". Chunks will not be decrypted.`
+                        );
+                        warned = true;
+                    }
                 }
             }
             if (currentLine.startsWith("#EXT-X-MAP")) {


### PR DESCRIPTION
..to avoid spamming when reading from a very long m3u8 (e.g. vod or pseudo-vod m3u8)