### PR TITLE
fixed NodeJS Version to 21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine AS builder
+FROM node:21-alpine AS builder
 
 COPY / /Minyami/
 


### PR DESCRIPTION
The dependencies listed in minyamis packages.json aren't yet compatible with NodeJS 22, that's why building the docker image currently fails.