### PR TITLE
get offset properly even when it's only 1 or 2 digit

### DIFF
--- a/src/core/parsers/nico.ts
+++ b/src/core/parsers/nico.ts
@@ -148,10 +148,11 @@ export default class Parser {
                 const firstChunkFilename = firstChunkUrl.match(/^(.+ts)/)[1];
                 let offset;
                 if (firstChunkFilename === "0.ts") {
-                    offset = downloader.m3u8.chunks[1].url.match(/(\d{3})\.ts/)[1];
+                    offset = downloader.m3u8.chunks[1].url.match(/(\d{1,3})\.ts/)[1];
                 } else {
-                    offset = downloader.m3u8.chunks[0].url.match(/(\d{3})\.ts/)[1];
+                    offset = downloader.m3u8.chunks[0].url.match(/(\d{1,3})\.ts/)[1];
                 }
+                offset = offset.padStart(3, "0");
                 const suffix = downloader.m3u8.chunks[0].url.match(/\.ts(.+)/)[1];
                 const newChunkList = [];
                 let counter = 0;


### PR DESCRIPTION
The old way cannot properly process the following m3u8 (which I encountered):

```m3u8
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-TARGETDURATION:5
#EXT-X-MEDIA-SEQUENCE:0
#EXT-X-START:TIME-OFFSET=0.0
#STREAM-DURATION:4440.021
#CURRENT-POSITION:0.042
#DMC-STREAM-DURATION:4440.021
#DMC-CURRENT-POSITION:0.042
#EXTINF:5.0,
42.ts?start=0.0&start_time=-572297465604&ht2_nicolive=4346020.0w4ty0ecip_sk25ag_7iacp11ig15q
#EXTINF:5.0,
5042.ts?start=0.0&start_time=-572297465604&ht2_nicolive=4346020.0w4ty0ecip_sk25ag_7iacp11ig15q
#EXTINF:5.0,
10042.ts?start=0.0&start_time=-572297465604&ht2_nicolive=4346020.0w4ty0ecip_sk25ag_7iacp11ig15q
#EXTINF:5.0,
15042.ts?start=0.0&start_time=-572297465604&ht2_nicolive=4346020.0w4ty0ecip_sk25ag_7iacp11ig15q
#EXTINF:5.0,
20042.ts?start=0.0&start_time=-572297465604&ht2_nicolive=4346020.0w4ty0ecip_sk25ag_7iacp11ig15q
#EXTINF:5.0,
25042.ts?start=0.0&start_time=-572297465604&ht2_nicolive=4346020.0w4ty0ecip_sk25ag_7iacp11ig15q
```