### PR TITLE
Fix --no-proxy option in minyami

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,9 @@ Erii.bind(
         if (options.verbose) {
             logger.enableDebugMode();
         }
-        if (!options.noProxy && !process.env.NO_PROXY) {
+        if (options.noProxy) {
+            ProxyAgent.disableProxy();
+        } else if (!process.env.NO_PROXY) {
             if (process.platform === "win32") {
                 await ProxyAgent.readWindowsSystemProxy();
             }

--- a/src/utils/agent.ts
+++ b/src/utils/agent.ts
@@ -83,6 +83,9 @@ class ProxyAgentHelper {
      * Note: environment variables will override system proxy in Windows.
      */
     readProxyConfigurationFromEnv() {
+        if (process.env.NO_PROXY) {
+            return;
+        }
         const proxySettings = process.env.ALL_PROXY || process.env.HTTP_PROXY || process.env.HTTPS_PROXY;
         if (proxySettings) {
             this.setProxy(process.env.ALL_PROXY || process.env.HTTP_PROXY || process.env.HTTPS_PROXY);
@@ -112,6 +115,13 @@ class ProxyAgentHelper {
         } catch {
             // ignore
         }
+    }
+
+    /**
+     * Disable proxy by setting proxyAgentInstance to null
+     */
+    disableProxy() {
+        this.proxyAgentInstance = null;
     }
 }
 

--- a/src/utils/m3u8.ts
+++ b/src/utils/m3u8.ts
@@ -32,6 +32,7 @@ export async function loadM3U8({ path, retries = 1, timeout = 60000, initPrimary
                         ...(!axios.defaults.headers.common["Host"] ? { Host: new URL(path).host } : {}),
                     },
                     cancelToken: source.token,
+                    proxy: proxyAgent ? undefined : false, // P3647
                 });
                 logger.info("M3U8 file fetched.");
                 m3u8Content = response.data;

--- a/src/utils/media.ts
+++ b/src/utils/media.ts
@@ -99,6 +99,7 @@ export function download(url: string, path: string, options: AxiosRequestConfig 
                 },
                 cancelToken: source.token,
                 ...options,
+                proxy: proxyAgentInstance ? undefined : false, // P8f0a
             });
             if (
                 response.headers["content-length"] &&
@@ -136,6 +137,7 @@ export async function requestRaw(url: string, options: AxiosRequestConfig = {}):
             Host: new URL(url).host,
         },
         ...options,
+        proxy: proxyAgentInstance ? undefined : false, // P8f0a
     });
 }
 /**


### PR DESCRIPTION
Fixes #144

Implement the `--no-proxy` option to disable the use of proxies, ignoring environment variables.

* **src/utils/agent.ts**
  - Add a new method `disableProxy` to set `proxyAgentInstance` to `null`.
  - Update the `readProxyConfigurationFromEnv` method to check for the `--no-proxy` option and skip reading proxy settings if it is enabled.

* **src/utils/m3u8.ts**
  - Update the `axios` requests to set the `proxy` option to `false` when the `--no-proxy` option is enabled.

* **src/utils/media.ts**
  - Update the `axios` requests to set the `proxy` option to `false` when the `--no-proxy` option is enabled.

* **src/index.ts**
  - Add a check for the `--no-proxy` option and call the `disableProxy` method if it is enabled.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Last-Order/Minyami/pull/145?shareId=5b8ec72f-b336-4fe2-bd3e-6487ff8289ce).